### PR TITLE
Edit Svg2Xaml\SvgReader.cs

### DIFF
--- a/Svg2Xaml\SvgReader.cs
+++ b/Svg2Xaml\SvgReader.cs
@@ -1,0 +1,29 @@
+//==========================================================================
+    /// <summary>
+    ///   Loads an SVG document and renders it into a 
+    ///   <see cref="DrawingImage"/>.
+    /// </summary>
+    /// <param name="uri">
+    ///   A <see cref="XmlReader"/> to read the XML structure of the SVG 
+    ///   document.
+    /// </param>
+    /// <param name="options">
+    ///   <see cref="SvgReaderOptions"/> to use for parsing respectively 
+    ///   rendering the SVG document.
+    /// </param>
+    /// <returns>
+    ///   A <see cref="DrawingImage"/> containing the rendered SVG document.
+    /// </returns>
+    public static DrawingImage Load(string uri, SvgReaderOptions options)
+    {
+        if (options == null)
+            options = new SvgReaderOptions();
+
+        XDocument document = XDocument.Load(uri);
+        if (document.Root.Name.NamespaceName != "http://www.w3.org/2000/svg")
+            throw new XmlException("Root element is not in namespace 'http://www.w3.org/2000/svg'.");
+        if (document.Root.Name.LocalName != "svg")
+            throw new XmlException("Root element is not an <svg> element.");
+
+        return new SvgDocument(document.Root, options).Draw();
+    }


### PR DESCRIPTION
Overloaded the SvgReader Load method to cater for a URI. The reason for this is the XDocument.Load method hangs for some .svg files when using the reader streams.
