### PR TITLE
make image tag support svg+xml image and use MemoryStream not temp file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ Generated_Code #added for RIA/Silverlight projects
 _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
+/.vs

--- a/Svg2Xaml/SvgImageElement.cs
+++ b/Svg2Xaml/SvgImageElement.cs
@@ -118,6 +118,10 @@ namespace Svg2Xaml
                 DataType = "png";
                 break;
 
+              case "svg+xml":
+                DataType = "svg+xml";
+                break;
+
               default:
                 throw new NotSupportedException(String.Format("Unsupported type: {0}", type));
             }

--- a/Svg2Xaml/SvgImageElement.cs
+++ b/Svg2Xaml/SvgImageElement.cs
@@ -129,18 +129,29 @@ namespace Svg2Xaml
     //==========================================================================
     public override Drawing GetBaseDrawing()
     {
-      if(Data == null)
-        return null;
-
-      string temp_file = Path.GetTempFileName();
-      using(FileStream file_stream = new FileStream(temp_file, FileMode.Create, FileAccess.Write))
-      using(BinaryWriter writer = new BinaryWriter(file_stream))
-        writer.Write(Data);
-
-      return new ImageDrawing(new BitmapImage(new Uri(temp_file)), new Rect(
-        new Point(X.ToDouble(), Y.ToDouble()),
-        new Size(Width.ToDouble(), Height.ToDouble())
-        ));
+        if (Data == null)
+          return null;
+        ImageSource imageSource = null;
+        switch (DataType)
+        {
+          case "jpeg":
+          case "png":
+              var bmp = new BitmapImage();
+              bmp.BeginInit();
+              bmp.StreamSource = new MemoryStream(Data);
+              bmp.EndInit();
+              imageSource = bmp;
+              break;
+          case "svg+xml":
+              imageSource = SvgReader.Load(new MemoryStream(Data));
+              break;
+        }
+        if (imageSource == null)
+          return null;
+        return new ImageDrawing(imageSource, new Rect(
+                      new Point(X.ToDouble(), Y.ToDouble()),
+                      new Size(Width.ToDouble(), Height.ToDouble())
+                      ));
     }
 
     //==========================================================================


### PR DESCRIPTION
1.SvgImageElement class don't support svg+xml  image,so I add it.
2.when SvgImageElement class load a image,it create a temp file,and never delete is.I make a change to use MemoryStream not use temp file.

PS:I forgot to add 'case' code block as follow

Line 121:
              case "svg+xml":
                DataType = "svg+xml";
                break;
